### PR TITLE
Sample output table has named rows

### DIFF
--- a/R/app.R
+++ b/R/app.R
@@ -207,7 +207,6 @@ calibrateSamples <- function(x){
 calibratedTable <- function(x){
     cal <- calibrate_it(x)
     tab <- data2table.calibrated(cal,log=x$log,cov=x$cov)
-    rownames(tab) <- NULL
     as.data.frame(tab)
 }
 

--- a/inst/www/js/simplex.js
+++ b/inst/www/js/simplex.js
@@ -1074,11 +1074,9 @@ function calibrate_table(){
     show('.show4processing');
     shinylight.call("calibratedTable", {x:glob}, null).then(
 	result => {
-	    hide('.show4processing')
-	    let nr = result.data.length;
-	    let header = Object.keys(result.data[0]);
-	    let tab = createDataEntryGrid('sample-calibration-table', header, nr);
-	    shinylight.setGridResult(tab, result);
+	    hide('.show4processing');
+	    let tab = createDataEntryGrid('sample-calibration-table', 1, 1);
+	    shinylight.setGridResultWithNamedRows(tab, result);
 	    show('.csv');
 	},
 	error => alert(error)


### PR DESCRIPTION
Using new function in Shinylight to set Sample calculation's output table to have named rows from the R data frame.